### PR TITLE
Annotation result loading both cards and table

### DIFF
--- a/backend/semant_annotation/db/crud_task.py
+++ b/backend/semant_annotation/db/crud_task.py
@@ -1,7 +1,7 @@
 import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import exc, select, or_, update
+from sqlalchemy import exc, select, or_, update, func
 from .database import DBError
 from . import model
 from semant_annotation.schemas import base_objects
@@ -71,7 +71,7 @@ async def get_task_instance_random(db: AsyncSession, task_id: UUID, result_count
         raise DBError(f'Failed fetching task instance from database.')
 
 
-async def get_task_instance_results(db: AsyncSession, task_id: UUID, user_id: UUID=None, from_date: datetime=None,
+async def get_task_instance_results(db: AsyncSession, task_id: UUID, offset: int, page_size: int, user_id: UUID=None, from_date: datetime=None, 
                                     to_date: datetime=None) -> base_objects.AnnotationTaskResult:
     try:
         async with db.begin():
@@ -83,13 +83,36 @@ async def get_task_instance_results(db: AsyncSession, task_id: UUID, user_id: UU
                 stmt = stmt.where(model.AnnotationTaskResult.created_date >= from_date)
             if to_date:
                 stmt = stmt.where(model.AnnotationTaskResult.created_date <= to_date)
+
+            stmt = stmt.offset(offset).limit(page_size)
             result = await db.execute(stmt)
             db_task_instance_result = result.scalars().all()
+
             return [base_objects.AnnotationTaskResult.model_validate(db_task_instance_result) for db_task_instance_result in db_task_instance_result]
     except exc.SQLAlchemyError as e:
         logging.error(str(e))
         raise DBError(f'Failed fetching task instance result from database.')
 
+async def get_task_instance_results_count(db: AsyncSession, task_id: UUID, user_id: UUID=None, from_date: datetime=None, 
+                                    to_date: datetime=None) -> int:
+    try:
+        async with db.begin():
+            stmt = select(func.count()).select_from(model.AnnotationTaskResult).join(model.AnnotationTaskInstance)\
+                .where(model.AnnotationTaskInstance.annotation_task_id == task_id)
+            if user_id:
+                stmt = stmt.where(model.AnnotationTaskResult.user_id == user_id)
+            if from_date:
+                stmt = stmt.where(model.AnnotationTaskResult.created_date >= from_date)
+            if to_date:
+                stmt = stmt.where(model.AnnotationTaskResult.created_date <= to_date)
+
+            result = await db.execute(stmt)
+            count = result.scalar()
+
+            return count
+    except exc.SQLAlchemyError as e:
+        logging.error(str(e))
+        raise DBError(f'Failed fetching total count of task instance results from database.')
 
 async def get_task_instance_result_times(db: AsyncSession, task_id: UUID = None, user_id: UUID=None, from_date: datetime=None,
                                     to_date: datetime=None) -> base_objects.SimplifiedAnnotationTaskResult:
@@ -113,4 +136,3 @@ async def get_task_instance_result_times(db: AsyncSession, task_id: UUID = None,
     except exc.SQLAlchemyError as e:
         logging.error(str(e))
         raise DBError(f'Failed fetching task instance result from database.')
-

--- a/backend/semant_annotation/schemas/base_objects.py
+++ b/backend/semant_annotation/schemas/base_objects.py
@@ -106,8 +106,8 @@ class AnnotationTaskInstance(AnnotationTaskInstanceUpdate):
 class SimplifiedAnnotationTaskResult(BaseModel):
     start_time: datetime
     end_time: datetime
-    result_type: AnnotationResultType
     user_id: UUID
+    subtasks: List[AnnotationSubtask] = []
 
     class Config:
         from_attributes = True
@@ -133,6 +133,8 @@ class AnnotationTaskResult(AnnotationTaskResultUpdate):
 
 class AnnotationTaskResultQuery(BaseModel):
     annotation_task_id: UUID
+    page: int
+    page_size: int 
     from_date: date = None
     to_date: date = None
     user_id: UUID = None

--- a/frontend/src/components/annotations/TaskInstance.vue
+++ b/frontend/src/components/annotations/TaskInstance.vue
@@ -17,23 +17,24 @@
 </template>
 
 <script setup lang="ts">
-import { defineComponent, defineProps, ref, onBeforeMount } from 'vue';
-import { uid, Loading } from 'quasar';
+import { ref, onBeforeMount, defineProps } from 'vue';
+import { Loading } from 'quasar';
 import { AnnotationTaskInstance } from 'src/models';
 import { api, apiURL } from 'src/boot/axios';
 import { useErrorStore } from 'src/stores/error';
 
-const errorStore = useErrorStore();
+interface Props {
+  taskInstanceId: string;
+}
 
+const props = defineProps<Props>();
+const errorStore = useErrorStore();
 const taskInstance = ref<AnnotationTaskInstance | null>(null);
 
-defineComponent({
-  name: 'AnnotationPage',
-});
 
 onBeforeMount(async () => {
   try {
-    // /api/task/task_instance_random/:task_id/:result_count
+    Loading.show();
     taskInstance.value = await api
       .get(`/task/task_instance/${props.taskInstanceId}/`)
       .then((response) => response.data);
@@ -47,10 +48,4 @@ onBeforeMount(async () => {
     Loading.hide();
   }
 });
-
-interface Props {
-  taskInstanceId: string;
-}
-
-const props = defineProps<Props>();
 </script>

--- a/frontend/src/pages/ResultsPage.vue
+++ b/frontend/src/pages/ResultsPage.vue
@@ -3,50 +3,53 @@
     <q-card class="q-pa-md">
       <q-card-section>
         <q-select
-                  v-model="selected_task"
-                  :options="tasks"
-                  label="Task"
-                  clearable
-                  option-label="name" />
+          v-model="selected_task"
+          :options="tasks"
+          label="Task"
+          clearable
+          option-label="name" />
         <q-select
-                  v-model="selected_user"
-                  :options="users"
-                  label="User"
-                  option-label="username"
-                  clearable />
+          v-model="selected_user"
+          :options="users"
+          label="User"
+          option-label="username"
+          clearable />
         <q-input v-model="from_date" label="From date" type="date" clearable />
         <q-input v-model="to_date" label="To date" type="date" clearable />
       </q-card-section>
-      <q-card-actions>
-        <q-btn
-               label="Load results"
-               color="primary"
-               @click="loadResults"
-               :disable="!selected_task" />
-        <q-tooltip v-if="!selected_task">Select task first</q-tooltip>
-      </q-card-actions>
       <q-btn v-if="showTable" label="Show table" @click="showTable = false" />
       <q-btn v-else label="Show cards" @click="showTable = true" />
     </q-card>
     <div v-if="results">
       <q-card class="q-pa-md">
         <q-card-section>
-          <div class="text-h6">Total results: {{ results.length }} </div>
-          <div class="text-h6">Annotated: {{ annotatedCount }} </div>
-          <div class="text-h6">Rejected: {{ rejectedCount }} </div>
+          <div v-if="selected_task" class="text-h6">Results:  {{ totalResults }} </div>
+          <div v-else class="text-h6">Results:  0 </div>
+          <!--div class="text-h6">Annotated: {{ annotatedCount }} </div-->
+          <!--div class="text-h6">Correction: {{ correctionCount }} </div-->
+          <!--div class="text-h6">Rejected: {{ rejectedCount }} </div-->
         </q-card-section>
       </q-card>
     </div>
 
+    <div v-if="results" class="q-pa-lg flex flex-center">
+      <q-pagination
+        v-model="currentPage"
+        :max="Math.ceil(totalResults / pageSize)"
+        @update:model-value="loadResults"
+        input
+      />
+    </div>
+
     <div v-if="showTable">
-      <q-table v-if="results" :rows="rows" :columns="columns" row-key="id" />
+      <q-table v-if="results" :rows="rows" :columns="columns" row-key="id"/>
     </div>
     <div v-else-if="results" class="row items-start">
-      <q-card v-for="result in rows" :key="result.id" class="q-ma-sm">
+      <q-card v-for="result in rows" :key="result.id" class="q-ma-sm" loading="lazy">
         <q-card-section>
           <div>User: {{ result.user }}</div>
-          <div>Created: {{ result.created_date }}</div>
-          <div>Type: {{ result.result_type }}</div>
+          <div>Date: {{ result.created_date }}</div>
+          <div>Type: <span :style="getResultTypeStyle(result.result_type)">{{ result.result_type }}</span></div>
           <TaskInstace :taskInstanceId="result.annotation_task_instance_id" />
         </q-card-section>
         <q-separator inset />
@@ -62,16 +65,20 @@
         </q-card-section>
       </q-card>
     </div>
+    
+    
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { defineComponent, ref, onMounted, computed } from 'vue';
+
+import { defineComponent, ref, onMounted, computed, watch } from 'vue';
 import { Loading } from 'quasar';
 import { AnnotationTask, AnnotationTaskResult, User } from 'src/models';
 import { api } from 'src/boot/axios';
 import { useErrorStore } from 'src/stores/error';
 import TaskInstace from 'src/components/annotations/TaskInstance.vue';
+
 
 defineComponent({
   name: 'ResultsPage',
@@ -88,12 +95,34 @@ const selected_task = ref<AnnotationTask | null>(null);
 const selected_user = ref<User | null>(null);
 const showTable = ref<boolean>(false);
 
+const currentPage = ref<number>(1);
+const pageSize = ref<number>(100); 
+const hasMoreResults = ref<boolean>(true);
+const totalResults = ref<number>(0);
+
+const getResultTypeStyle = (resultType: string) => {
+  const styles = {
+    rejected: { color: 'red', 'font-weight': 'bold', 'font-size': '1.2em' },
+    new: { color: 'green', 'font-weight': 'bold', 'font-size': '1.2em' },
+    correction: { color: 'yellow', 'font-weight': 'bold', 'font-size': '1.2em' },
+  };
+
+  return styles[resultType] || {};
+};
+
 const rejectedCount = computed(() => {
   if (!results.value) {
     return 0;
   }
   return results.value.filter((r) => r.result_type == 'rejected').length;
-});
+});``
+
+const correctionCount = computed(() => {
+  if (!results.value) {
+    return 0;
+  }
+  return results.value.filter((r) => r.result_type == 'correction').length;
+});``
 
 const annotatedCount = computed(() => {
   if (!results.value) {
@@ -101,6 +130,7 @@ const annotatedCount = computed(() => {
   }
   return results.value.filter((r) => r.result_type == 'new').length;
 });
+
 
 let baseColumns = [
   {
@@ -115,7 +145,18 @@ let baseColumns = [
     label: 'Type',
     field: 'result_type',
     align: 'left',
-    sortable: true,
+    sortable: true,    
+    style: (row) => {
+      if (row.result_type === 'rejected') {
+        return 'color: red';
+      } else if (row.result_type === 'new') {
+        return 'color: green';
+      } else if (row.result_type === 'correction') {
+        return 'color: yellow';
+      }
+      // Return null for default style
+      return null;
+    },
   },
   {
     name: 'created_date',
@@ -123,6 +164,7 @@ let baseColumns = [
     field: 'created_date',
     align: 'left',
     sortable: true,
+    
   },
 ];
 
@@ -153,22 +195,33 @@ const rows = computed(() => {
   let rows = [];
   for (let result of results.value) {
     const user = users.value.find((u) => u.id == result.user_id);
+    
+    let currentTime = new Date(result.created_date)
+    let selectedDate = currentTime.toISOString().slice(0, 10);
+    let timeFrom = currentTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    let date = `${selectedDate} ${timeFrom}`;
+
     let row = {
       id: result.id,
       user: user?.username || 'unknown',
       annotation_task_instance_id: result.annotation_task_instance_id,
       result_type: result.result_type,
-      created_date: result.created_date,
+      created_date: date,
     };
 
     const subResults = JSON.parse(result.result);
     for (const [key, value] of Object.entries(subResults)) {
-      // value is a list of string, needs to be joined
-      row[key] = value;
-    }
+      if (showTable.value) {
+        row[key] = value.map((item: any) => item.text).join(", ");
+      } else {
+        row[key] = value;
+      }
+  }
+
     rows.push(row);
   }
-  console.log(rows);
+  console.log("ahoj")
+  //console.log(rows);
   return rows;
 });
 
@@ -181,6 +234,15 @@ onMounted(async () => {
   console.log(users.value);
 });
 
+
+watch([selected_task, selected_user], async ([newTask, newUser]) => {
+  if (newTask) {
+    await loadInitialResults();
+  } else {
+    results.value = [];
+    totalResults.value = 0;
+  }
+});
 async function loadTasks () {
   try {
     Loading.show({ delay: 300 });
@@ -203,13 +265,28 @@ async function loadUsers () {
   }
 }
 
+
+async function loadInitialResults() {
+  currentPage.value = 1;
+  results.value = [];
+  hasMoreResults.value = true;
+  totalResults.value = 0;
+  await loadResults();
+}
+
 async function loadResults () {
   if (!selected_task.value) {
     return;
   }
   try {
     Loading.show({ delay: 300 });
-    let query = { annotation_task_id: selected_task.value.id };
+
+    let query = {
+      annotation_task_id: selected_task.value.id,
+      page: currentPage.value,
+      page_size: pageSize.value,
+    };
+
     if (selected_user.value) {
       query['user_id'] = selected_user.value.id;
     }
@@ -220,9 +297,26 @@ async function loadResults () {
       query['to_date'] = to_date.value;
     }
 
-    results.value = await api
+    console.log("kulo")
+
+    const newResults = await api
       .post('/task/results', query)
       .then((res) => res.data);
+
+    const newTotal = await api
+      .post('/task/results/count', query)
+      .then((res) => res.data);
+
+    totalResults.value = newTotal
+
+    results.value = newResults;
+
+    if (newResults.length < pageSize.value) {
+      hasMoreResults.value = false; 
+    } else {
+      hasMoreResults.value = true;
+    }
+
     // sort results by results[i].user_id and then results[i].end_time
     results.value.sort((a, b) => {
       if (a.user_id < b.user_id) {
@@ -243,10 +337,16 @@ async function loadResults () {
 
   } catch (error) {
     errorStore.reportError('Error', 'Failed to get results.', error);
+    // report na backend v reportError
   } finally {
     Loading.hide();
   }
 }
+
+
+
+
+
 /*    <q-table
       v-if="results"
       :data="results"


### PR DESCRIPTION
100 results per page, standard paging in quasar
result type differentiated by color
fixed table issue with loading sub tasks
removed button for loadResult = using watcher triggered by selected task and user 
(forgot to add from and to date trigger, will add in next push)